### PR TITLE
Update Observer to actually send out sms using twilio

### DIFF
--- a/app/code/community/Kojoman/Twilio/Model/Observer.php
+++ b/app/code/community/Kojoman/Twilio/Model/Observer.php
@@ -1,9 +1,37 @@
 <?php
 
-include(Mage::getBaseDir('lib').'/twilio-php/Services/Twilio.php');
+require_once(Mage::getBaseDir('lib').'/twilio-php/Services/Twilio.php');
+
+//require_once('twilio-php/Services/Twilio.php');
+
 
 class Kojoman_Twilio_Model_Observer extends Services_Twilio
 {
+
+	protected $AccountSid;
+	protected $AuthToken;
+
+	// Dummy variables for testing. Change to something better
+	// or use data passed from Observer. 
+	protected $name = "Kojoman";
+	protected $twilio_number = "1-646-XXX-XXXX"; 	//Remember to change this
+	protected $to = "XXX-XXX-XXXX"; 
+	protected $message = "Kojoman just added an item to his cart";
+
+
+	//protected $twilio = new Services_Twilio($this->AccountSid, $this->AuthToken);
+
+	//protected $twilio = Services_Twilio("abc", "$this->AuthToken");
+
+	public function __construct()
+	{
+		$decryptor = Mage::helper('core');
+
+		$this->AccountSid = Mage::helper('twilio')->getAccountSID();
+		$this->AuthToken  = Mage::helper('twilio')->getAuthToken();
+
+		parent::__construct($this->AccountSid, $this->AuthToken);
+	}
 
 	protected function _debug($object) 
 	{
@@ -18,12 +46,24 @@ class Kojoman_Twilio_Model_Observer extends Services_Twilio
 			return; 
 		}
 
-		//Mage::log('hello');
+		try {
+			$sms = $this->account->messages->sendMessage(
+				$this->twilio_number,
+				$this->to,
+				$this->message
+			); 
+		
+			Mage::log($sms);
 
-		$order = $observer->getEvent()->getData('order');
+			$product = $observer->getEvent()->getData();
 
-		$this->_debug($order);
+			Mage::log($product);
 
-		//return $this; 
+			//$this->_debug($sms);
+		} catch (Exception $e) {
+			Mage::logException($e);
+		}
+		
+		return $this; 
 	}
 }


### PR DESCRIPTION
I had to comment out personal numbers for obvious reasons.  Will implement a better way soon but if you're impatient you can just replace the placeholder numbers with a real twilio number and a recipient and it should work.
